### PR TITLE
BAH-1256 Add a button to start ad-hoc tele-consultation in the header section in the ‘Patient Dashboard’ Screen.

### DIFF
--- a/openmrs/apps/clinical/app.json
+++ b/openmrs/apps/clinical/app.json
@@ -27,6 +27,7 @@
         "enableRadiologyOrderOptions":["Urgent","NeedsPrint"],
         "enableLabOrderOptions":["Urgent", "NeedsPrint"],
         "quickPrints":false,
+        "allowAdhocTeleConsultation": false,
         "networkConnectivity" : {
             "showNetworkStatusMessage": false,
             "networkStatusCheckInterval": 20000,


### PR DESCRIPTION
Refer https://bahmni.atlassian.net/browse/BAH-1256
added new config variable allowAdhocTeleConsultation to show/hide adhoc teleconsultation button