### PR TITLE
BAH-2019 | Update Appointments URL

### DIFF
--- a/openmrs/apps/home/extension.json
+++ b/openmrs/apps/home/extension.json
@@ -125,7 +125,7 @@
     "extensionPointId": "org.bahmni.home.dashboard",
     "type": "link",
     "translationKey": "MODULE_LABEL_APPOINTMENT_SCHEDULING_KEY",
-    "url": "../../appointments-v2",
+    "url": "../../appointments",
     "icon": "fa fa-calendar",
     "order": 14,
     "requiredPrivilege": "app:appointments"


### PR DESCRIPTION
SInce older version of appointments from bahmniapps is deprecated and is removed, setting the appointments URL as just `appointments`

JIRA: https://bahmni.atlassian.net/browse/BAH-2019

Co-authored-by: Divij Goyal <divij.g@beehyv.com>