### PR TITLE
BS-48 | Add target terminology server to config

### DIFF
--- a/openmrs/apps/clinical/app.json
+++ b/openmrs/apps/clinical/app.json
@@ -29,6 +29,7 @@
         "quickPrints":false,
         "allowAdhocTeleConsultation": false,
         "teleConsultationDomain": "meet.jit.si",
+        "targetTerminologyServer": "snomed",
         "networkConnectivity" : {
             "showNetworkStatusMessage": false,
             "networkStatusCheckInterval": 20000,


### PR DESCRIPTION
This Pull Request adds a target terminology server to the config file. The config will now have a switch that allows users to choose between the default terminology server or SNOMED as the target terminology server.