### PR TITLE
BAH-2766 | Analytics Icon on Bahmni home page

### DIFF
--- a/openmrs/apps/home/whiteLabel.json
+++ b/openmrs/apps/home/whiteLabel.json
@@ -54,6 +54,13 @@
 			"title": "Radiology",
 			"logo": "/bahmni/images/pac.png",
 			"link": "/dcm4chee-web3"
+		},
+		{
+			"enabled": true,
+			"name": "metabase",
+			"title": "Analytics",
+			"logo": "/bahmni/images/analytics.png",
+			"link": "/metabase"
 		}
 	]
 }


### PR DESCRIPTION
A Metabase logo should be added to Bahmni-dev lite [home page](https://dev.lite.mybahmni.in/) and Bahmni using docker-compose. (both Bahmni-Standard and Bahmni Lite )  so that the user can directly navigate to metabase from bahmni home page.

## Jira
---------
https://bahmni.atlassian.net/browse/BAH-2766