### PR TITLE
BAH-2489-update| Added configuration for encounterType

### DIFF
--- a/openmrs/apps/clinical/visit.json
+++ b/openmrs/apps/clinical/visit.json
@@ -43,7 +43,12 @@
                 "displayOrder": 2,
                 "config": { }
             }
-        }
+        },
+            "encounterContext": {
+                "filterEncounterTypes": [
+                    "Consultation"
+                ]
+            }
     },
     "dischargeSummary":{
         "translationKey": "DASHBOARD_TAB_DISCHARGE_SUMMARY_KEY",
@@ -157,7 +162,12 @@
                     "scope": "latest"
                 }
             }
-        }
+        },
+            "encounterContext": {
+                "filterEncounterTypes": [
+                    "Consultation"
+                ]
+            }
     },
     "orders":{
       "translationKey": "DASHBOARD_TAB_ORDERS_KEY",


### PR DESCRIPTION
This will give the ability for the implementer to configure the encounter types they would want to consider and display doctor name based on this configuration.If this configuration is added it would filter the encounters based on this encounterType and display doctor name in patient Summary accordingly.