### PR TITLE
BAH-3219 | Fixed sqlPath location

### DIFF
--- a/openmrs/apps/reports/reports.json
+++ b/openmrs/apps/reports/reports.json
@@ -169,7 +169,7 @@
         "type": "ElisGeneric",
         "requiredPrivilege": "app:reports",
         "config": {
-            "sqlPath": "/var/www/bahmni_config/openmrs/apps/reports/sql/testCount.sql"
+            "sqlPath": "/etc/bahmni_config/openmrs/apps/reports/sql/testCount.sql"
         }
     },
     "bloodPressure": {


### PR DESCRIPTION
Given that bahmni-reports running in docker now loads this under `/etc/`, the absolute path should reflect that.
Ideally it might be that these paths should be relative and not absolute, but I don't know enough about the various implementations to have a strong opinion on that.

Can be tested by standing up a default Bahmni-Standard installation and checking whether you can run the "Generic Laboratory Report" or not.

Let me know any other info you need.

Edit: Relevant JIRA task is here:
https://bahmni.atlassian.net/browse/BAH-3219