### PR TITLE
BAH-3516 | Fix. Print Types In Visits Config

### DIFF
--- a/openmrs/apps/clinical/visit.json
+++ b/openmrs/apps/clinical/visit.json
@@ -37,6 +37,21 @@
                     "orderType": "Radiology Order"
                 }
             },
+            "labInvestigations":{
+                "type": "labOrders",
+                "displayOrder": 6,
+                "config": {
+                    "translationKey":"LAB_INVESTIGATION",
+                    "showChart": true,
+                    "showTable": false,
+                    "showNormalLabResults": true,
+                    "showCommentsExpanded": true,
+                    "showAccessionNotes": true,
+                    "numberOfVisits": 10,
+                    "initialAccessionCount": 1,
+                    "latestAccessionCount": 1
+                }
+            },
             "conditions": {
                 "title": "Conditions",
                 "type": "conditionsList",
@@ -97,6 +112,7 @@
             "diagnoses":{
                 "type": "diagnosis",
                 "displayOrder": 4,
+                "title": "Diagnosis",
                 "config": {
                     "translationKey" : "DISCHARGE_SUMMARY_DIAGNOSIS_KEY",
                     "showCertainty": false,
@@ -121,7 +137,7 @@
                 }
             },
             "labInvestigations":{
-                "type": "investigationResult",
+                "type": "labOrders",
                 "displayOrder": 6,
                 "config": {
                     "translationKey":"LAB_INVESTIGATION",
@@ -136,11 +152,11 @@
                 }
             },
             "Treatments": {
-                "type": "treatment",
+                "translationKey": "VISIT_TITLE_TREATMENTS_KEY",
+                "type":"prescription",
                 "displayOrder": 6,
                 "config": {
-                    "translationKey": "VISIT_TITLE_TREATMENTS_KEY",
-                    "showFlowSheet": true,
+                    "showFlowSheet": false,
                     "showListView": true,
                     "showOtherActive": false,
                     "showDetailsButton": true,


### PR DESCRIPTION
JIRA -> [BAH-3516](https://bahmni.atlassian.net/browse/BAH-3516)

This PR addresses an issue encountered in the Bahmni Lite refactorings and release, where certain display control type keys in the visitSummary.html file were changed, resulting in missing entries from the visit dashboard. To rectify the issue, the necessary modifications have been implemented in the visitSummary.html file. Specifically, the display control type keys have been updated as per the new mappings:
1. investigationChart has been replaced with labOrders
2. treatment has been replaced with prescription
3. A title key has been added to the diagnosis section to ensure proper rendering 