### PR TITLE
BAH-3512 | Add. Configuration Properties to Sort Lab Orders By Name and Result Columns in Descending Order By Date

### DIFF
--- a/openmrs/apps/clinical/dashboard.json
+++ b/openmrs/apps/clinical/dashboard.json
@@ -174,8 +174,8 @@
                     "showAccessionNotes": true,
                     "showDetailsButton":false,
                     "chartConfig": {
-                        "sortLabOrdersByName":true,
-                        "sortResultColumnsLatestFirst":true
+                        "sortLabOrdersByName":false,
+                        "sortResultColumnsLatestFirst":false
                     }  
                 },
                 "expandedViewConfig":{  

--- a/openmrs/apps/clinical/dashboard.json
+++ b/openmrs/apps/clinical/dashboard.json
@@ -174,7 +174,8 @@
                     "showAccessionNotes": true,
                     "showDetailsButton":false,
                     "chartConfig": {
-                        "sortLabOrdersByName":true
+                        "sortLabOrdersByName":true,
+                        "sortResultColumnsLatestFirst":true
                     }  
                 },
                 "expandedViewConfig":{  
@@ -182,7 +183,8 @@
                     "showChart":true,
                     "showTable":false,
                     "chartConfig": {
-                        "sortLabOrdersByName":true
+                        "sortLabOrdersByName":true,
+                        "sortResultColumnsLatestFirst":true
                     }  
                 }
             },

--- a/openmrs/apps/clinical/dashboard.json
+++ b/openmrs/apps/clinical/dashboard.json
@@ -175,7 +175,9 @@
                     "showDetailsButton":false
                 },
                 "expandedViewConfig":{  
-                    "numberOfVisits":10
+                    "numberOfVisits":10,
+                    "showChart":true,
+                    "showTable":false
                 }
             },
             "nutritionalValues":{  

--- a/openmrs/apps/clinical/dashboard.json
+++ b/openmrs/apps/clinical/dashboard.json
@@ -172,12 +172,18 @@
                     "showNormalLabResults": true,
                     "showCommentsExpanded": true,
                     "showAccessionNotes": true,
-                    "showDetailsButton":false
+                    "showDetailsButton":false,
+                    "chartConfig": {
+                        "sortLabOrdersByName":true
+                    }  
                 },
                 "expandedViewConfig":{  
                     "numberOfVisits":10,
                     "showChart":true,
-                    "showTable":false
+                    "showTable":false,
+                    "chartConfig": {
+                        "sortLabOrdersByName":true
+                    }  
                 }
             },
             "nutritionalValues":{  

--- a/openmrs/apps/clinical/visit.json
+++ b/openmrs/apps/clinical/visit.json
@@ -49,7 +49,11 @@
                     "showAccessionNotes": true,
                     "numberOfVisits": 10,
                     "initialAccessionCount": 1,
-                    "latestAccessionCount": 1
+                    "latestAccessionCount": 1,
+                    "chartConfig": {
+                        "sortLabOrdersByName":true,
+                        "sortResultColumnsLatestFirst":true
+                    } 
                 }
             },
             "conditions": {
@@ -148,7 +152,11 @@
                     "showAccessionNotes": true,
                     "numberOfVisits": 10,
                     "initialAccessionCount": 1,
-                    "latestAccessionCount": 1
+                    "latestAccessionCount": 1,
+                    "chartConfig": {
+                        "sortLabOrdersByName":true,
+                        "sortResultColumnsLatestFirst":true
+                    } 
                 }
             },
             "Treatments": {

--- a/openmrs/apps/clinical/visit.json
+++ b/openmrs/apps/clinical/visit.json
@@ -48,8 +48,6 @@
                     "showCommentsExpanded": true,
                     "showAccessionNotes": true,
                     "numberOfVisits": 10,
-                    "initialAccessionCount": 1,
-                    "latestAccessionCount": 1,
                     "chartConfig": {
                         "sortLabOrdersByName":true,
                         "sortResultColumnsLatestFirst":true


### PR DESCRIPTION
JIRA -> [BAH-3512](https://bahmni.atlassian.net/browse/BAH-3512)

In this PR, the following changes have been made:

1. Hide the table view  from the expanded view of lab results in patient dashboard by setting "showTable" to false. 
2. Introduced new property "sortLabOrdersByName" as a chartConfig, which can be set to true if we want to sort the lab orders in alphabetical order in the chart view.
3. Introduced new property "sortResultColumnsLatestFirst" as a chartConfig, which can be set to true if we want to sort the lab results columns in descending order by date (i.e, latestFirst).