### PR TITLE
BAH-4035 | Add sample patient admit tasks to eventsConfig.json

### DIFF
--- a/openmrs/apps/ipdDashboard/eventsConfig.json
+++ b/openmrs/apps/ipdDashboard/eventsConfig.json
@@ -1,7 +1,17 @@
 [
     {
         "type": "PATIENT_ADMIT",
-        "tasks": []
+        "tasks": [
+            {
+                "name": "Collect patient history"
+            },
+            {
+                "name": "Record medications taken by the patient already"
+            },
+            {
+                "name": "Record Vitals"
+            }
+        ]
     },
     {
         "type": "SHIFT_START_TASK",


### PR DESCRIPTION
This PR adds sample non-medication tasks to eventsConfig.json for PATIENT_ADMIT event